### PR TITLE
feat: add --eml export and UTF-8 subject encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@mariozechner/gmcli",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mariozechner/gmcli",
-			"version": "0.1.0",
+			"version": "0.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"google-auth-library": "^10.1.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,10 +43,11 @@ GMAIL COMMANDS
         label:Work, label:UNREAD
         Combine: "in:inbox is:unread from:boss@company.com"
 
-  gmcli <email> thread <threadId> [--download]
+  gmcli <email> thread <threadId> [--download] [--eml]
       Get thread with all messages.
       Shows: Message-ID, headers, body, attachments.
       --download saves attachments to ~/.gmcli/attachments/
+      --eml exports all messages as .eml files to ~/.gmcli/eml/
 
   gmcli <email> labels list
       List all labels with ID, name, and type.
@@ -266,10 +267,25 @@ async function handleSearch(account: string, args: string[]) {
 
 async function handleThread(account: string, args: string[]) {
 	const download = args.includes("--download");
-	const filtered = args.filter((a) => a !== "--download");
+	const eml = args.includes("--eml");
+	const filtered = args.filter((a) => a !== "--download" && a !== "--eml");
 	const threadId = filtered[0];
 
-	if (!threadId) error("Usage: <email> thread <threadId>");
+	if (!threadId) error("Usage: <email> thread <threadId> [--download] [--eml]");
+
+	// Handle --eml export
+	if (eml) {
+		const results = await service.exportThreadEml(account, threadId);
+		if (jsonOutput) {
+			console.log(JSON.stringify(results));
+		} else {
+			console.log("MESSAGE_ID\tFILENAME\tPATH\tSIZE");
+			for (const r of results) {
+				console.log(`${r.messageId}\t${r.filename}\t${r.path}\t${r.size}`);
+			}
+		}
+		return;
+	}
 
 	const result = await service.getThread(account, threadId, download);
 

--- a/src/gmail-service.ts
+++ b/src/gmail-service.ts
@@ -227,6 +227,48 @@ export class GmailService {
 		return downloadedAttachments;
 	}
 
+	async getMessageRaw(email: string, messageId: string): Promise<Buffer> {
+		const gmail = this.getGmailClient(email);
+		const response = await gmail.users.messages.get({
+			userId: "me",
+			id: messageId,
+			format: "raw",
+		});
+		if (!response.data.raw) {
+			throw new Error("No raw data in message");
+		}
+		return Buffer.from(response.data.raw, "base64url");
+	}
+
+	async exportThreadEml(
+		email: string,
+		threadId: string,
+		outputDir?: string,
+	): Promise<Array<{ messageId: string; filename: string; path: string; size: number }>> {
+		const gmail = this.getGmailClient(email);
+		const response = await gmail.users.threads.get({
+			userId: "me",
+			id: threadId,
+		});
+		const thread = response.data;
+		const emlDir = outputDir || path.join(os.homedir(), ".gmcli", "eml");
+		if (!fs.existsSync(emlDir)) {
+			fs.mkdirSync(emlDir, { recursive: true });
+		}
+		const results: Array<{ messageId: string; filename: string; path: string; size: number }> = [];
+		for (const message of thread.messages || []) {
+			const raw = await this.getMessageRaw(email, message.id!);
+			const headers = message.payload?.headers || [];
+			const subject = headers.find((h: any) => h.name?.toLowerCase() === "subject")?.value || "no-subject";
+			const safeSubject = subject.replace(/[^a-zA-Z0-9-_]/g, "_").substring(0, 50);
+			const filename = `${message.id}_${safeSubject}.eml`;
+			const filePath = path.join(emlDir, filename);
+			fs.writeFileSync(filePath, raw);
+			results.push({ messageId: message.id!, filename, path: filePath, size: raw.length });
+		}
+		return results;
+	}
+
 	async downloadAttachments(
 		email: string,
 		attachments: Array<{ messageId: string; attachmentId: string; filename: string }>,
@@ -346,6 +388,15 @@ export class GmailService {
 		return labels.map((l) => nameToId.get(l.toLowerCase()) || l);
 	}
 
+	private encodeSubject(subject: string): string {
+		// Check if subject contains non-ASCII characters
+		if (!/^[\x00-\x7F]*$/.test(subject)) {
+			const encoded = Buffer.from(subject, "utf8").toString("base64");
+			return `=?UTF-8?B?${encoded}?=`;
+		}
+		return subject;
+	}
+
 	async createDraft(
 		email: string,
 		to: string[],
@@ -392,7 +443,7 @@ export class GmailService {
 			`To: ${to.join(", ")}`,
 			options.cc?.length ? `Cc: ${options.cc.join(", ")}` : "",
 			options.bcc?.length ? `Bcc: ${options.bcc.join(", ")}` : "",
-			`Subject: ${subject}`,
+			`Subject: ${this.encodeSubject(subject)}`,
 			inReplyTo ? `In-Reply-To: ${inReplyTo}` : "",
 			references ? `References: ${references}` : "",
 			"MIME-Version: 1.0",
@@ -547,7 +598,7 @@ export class GmailService {
 			`To: ${to.join(", ")}`,
 			options.cc?.length ? `Cc: ${options.cc.join(", ")}` : "",
 			options.bcc?.length ? `Bcc: ${options.bcc.join(", ")}` : "",
-			`Subject: ${subject}`,
+			`Subject: ${this.encodeSubject(subject)}`,
 			inReplyTo ? `In-Reply-To: ${inReplyTo}` : "",
 			references ? `References: ${references}` : "",
 			"MIME-Version: 1.0",


### PR DESCRIPTION
## Summary

This PR adds two features:

### 1. Export threads as .eml files (`--eml` flag)

```bash
gmcli you@gmail.com thread <threadId> --eml
```

Exports all messages in a thread as RFC 822 .eml files to `~/.gmcli/eml/`. Useful for:
- Archiving emails
- Forwarding as attachments (since there's no native forward)
- Processing with other tools

New methods:
- `getMessageRaw(email, messageId)` - fetch message in raw format
- `exportThreadEml(email, threadId, outputDir?)` - export thread to .eml files

### 2. UTF-8 subject encoding

Subjects with non-ASCII characters are now properly encoded using RFC 2047 (Base64):

```
Subject: =?UTF-8?B?...?=
```

Before: "Más información" → garbled text
After: "Más información" → displays correctly

Applied to both `createDraft()` and `sendMessage()`.

## Testing

Tested manually with Spanish subjects containing accents (á, é, í, ó, ú, ñ) and .eml export/import in various email clients.