### PR TITLE
fix: RFC 2047 MIME encoding for non-ASCII email subjects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@mariozechner/gmcli",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mariozechner/gmcli",
-			"version": "0.1.0",
+			"version": "0.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"google-auth-library": "^10.1.0",

--- a/src/gmail-service.ts
+++ b/src/gmail-service.ts
@@ -59,6 +59,17 @@ export class GmailService {
 	private accountStorage = new AccountStorage();
 	private gmailClients: Map<string, any> = new Map();
 
+	/**
+	 * Encode a header value per RFC 2047 if it contains non-ASCII characters.
+	 * Uses Base64 encoded-word syntax: =?UTF-8?B?<base64>?=
+	 */
+	private encodeHeaderValue(value: string): string {
+		if (/[^\x00-\x7F]/.test(value)) {
+			return `=?UTF-8?B?${Buffer.from(value).toString("base64")}?=`;
+		}
+		return value;
+	}
+
 	async addGmailAccount(email: string, clientId: string, clientSecret: string, manual = false): Promise<void> {
 		if (this.accountStorage.hasAccount(email)) {
 			throw new Error(`Account '${email}' already exists`);
@@ -392,7 +403,7 @@ export class GmailService {
 			`To: ${to.join(", ")}`,
 			options.cc?.length ? `Cc: ${options.cc.join(", ")}` : "",
 			options.bcc?.length ? `Bcc: ${options.bcc.join(", ")}` : "",
-			`Subject: ${subject}`,
+			`Subject: ${this.encodeHeaderValue(subject)}`,
 			inReplyTo ? `In-Reply-To: ${inReplyTo}` : "",
 			references ? `References: ${references}` : "",
 			"MIME-Version: 1.0",
@@ -547,7 +558,7 @@ export class GmailService {
 			`To: ${to.join(", ")}`,
 			options.cc?.length ? `Cc: ${options.cc.join(", ")}` : "",
 			options.bcc?.length ? `Bcc: ${options.bcc.join(", ")}` : "",
-			`Subject: ${subject}`,
+			`Subject: ${this.encodeHeaderValue(subject)}`,
 			inReplyTo ? `In-Reply-To: ${inReplyTo}` : "",
 			references ? `References: ${references}` : "",
 			"MIME-Version: 1.0",


### PR DESCRIPTION
## Problem

When creating a draft or sending an email with non-ASCII characters in the subject (e.g., accented characters in Portuguese, French, German, etc.), Gmail displays garbled text.

**Example:**
- Input subject: `Relatório de Comissões - Segunda Quinzena de Março`
- Gmail displays: `RelatÃ³rio de ComissÃµes - Segunda Quinzena de MarÃ§o`

## Cause

The `Subject` header is set as plain UTF-8 text, but per RFC 2047, non-ASCII values in email headers must use MIME encoded-word syntax. The message body correctly uses `Content-Type: text/plain; charset=UTF-8`, but headers need their own encoding.

## Fix

Added `encodeHeaderValue()` private method that applies RFC 2047 Base64 encoded-word syntax (`=?UTF-8?B?...?=`) only when non-ASCII characters are present. ASCII-only subjects are left unchanged. Applied to both `createDraft()` and `sendEmail()`.